### PR TITLE
added a basic /e/ endpoint for emojis, very WIP

### DIFF
--- a/lib/Myriad/Controller/Emoji.pm6
+++ b/lib/Myriad/Controller/Emoji.pm6
@@ -1,0 +1,27 @@
+unit package Myriad::Controller::Emoji;
+use Myriad::Controller::Statistics;
+use Cro::HTTP::Router;
+
+sub emoji(%defaults, $dbh) is export {
+    route {
+        get -> 'e', $expression is copy {
+        log-request;
+        $expression = $expression.lc().trim();
+        my $sth = $dbh.prepare(qq:to/STATEMENT/);
+           SELECT sid AS sid,
+                  name AS name,
+                  find AS code,
+                  image AS image
+             FROM %defaults<database-table-prefix>_smilies
+            WHERE name ILIKE ?
+         ORDER BY disporder DESC
+            LIMIT 15
+        STATEMENT
+        my $result = $sth.execute("$expression%");
+        my @rows = $sth.allrows(:array-of-hash);
+        log-successful-request if $result > 0;
+        content 'application/json', @rows;
+        }
+    }
+}
+

--- a/lib/Myriad/Controller/Emoji.pm6
+++ b/lib/Myriad/Controller/Emoji.pm6
@@ -8,8 +8,7 @@ sub emoji(%defaults, $dbh) is export {
         log-request;
         $expression = $expression.lc().trim();
         my $sth = $dbh.prepare(qq:to/STATEMENT/);
-           SELECT sid AS sid,
-                  name AS name,
+           SELECT name AS name,
                   find AS code,
                   image AS image
              FROM %defaults<database-table-prefix>_smilies

--- a/myriad.p6
+++ b/myriad.p6
@@ -4,6 +4,7 @@ use Cro::HTTP::Server;
 
 use Myriad::Controller::Users;
 use Myriad::Controller::Threads;
+use Myriad::Controller::Emoji;
 use Myriad::Controller::Statistics;
 
 my %defaults = database-hostname => %*ENV<MYRIAD_DATABASE_HOST> || 'localhost',
@@ -28,6 +29,8 @@ my $application = route {
     include users(%defaults, $dbh);
 
     include threads(%defaults, $dbh);
+
+    include emoji(%defaults, $dbh);
 
     if %defaults<debug-mode> {
         include statistics;


### PR DESCRIPTION
WIP, I'm still not sure if this is optimal or not. Do we need the `sid` at all if we're just creating an API designed for autocomplete systems to hook into? I think it can be removed since we only need the name, expression (`find` column) and possibly the image path as a preview on drop-down menus.